### PR TITLE
Add infrastructure for storing exercises in individual .md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ Load index.html from a live server (also needs improving upon)
 
 # Contributing exercises
 
+Some conventions are set up to interact with the app, to facilitate testing and markup of block names and starting html.
+
+## Naming
+
+By convention (not currently necessary, but possibly useful in future):
+
+- exercises are named exercise_XXXXX
+- md file for exercise_XXXX are in exercises/XXXX.md
+- introduction is an exception
+
+## Referring to blocks
+
 All blocks should have consistent names and be marked up consistently (for easy renaming, or improved rendering), using either
 
 ```html
@@ -52,6 +64,8 @@ in html or
 ```
 
 in markdown.
+
+## Providing initial html
 
 Each exercise includes its default/starting html. It should be either marked as
 
@@ -72,3 +86,44 @@ in html or be the first html code block in markdown:
   <li id="strawberry">Strawberry</li>
 </ul>
 ```
+
+## Placeholder for placing a pass/fail testmark for a test
+
+In html, write the id of the test ("<exercise_id><expect_index>") in the corresponding li element classname
+
+```html
+<li id="exercise_set_colours_3">
+  <!-- linked to BlocklyTest.registerTest("exercise_set_colours") ... BlocklyTest.expect(3)-->
+</li>
+```
+
+In markdown, write an empty html span out. BlocklyTest.expect will be lined up by order of appearance
+
+```html
+<span class="test-checkbox"></span>
+```
+
+## Registering tests
+
+The test for an exercise is registered
+
+- once per exercise
+- inside the html for that exercise
+- by calling `BlocklyTest.registerTest` with the id attribute for the exercise and a callback to setup expectations
+
+The callback is executed when the run button has been pressed, after the html has been rendered, but before the code is executed. It sets up expectations of the things that should happen after the code is executed.
+
+`BlocklyTest.expect` has
+
+- a numeric attribute (should be 1..n in order of where the checkboxes appear in the instructions)
+- a text describing what should be true for the test to succeed
+- a dom element whose changes are to be observed
+- a predicate to be executed every time the dom element changes, to verify if the result is now true
+
+`BlocklyTest.expectAfterClick` has
+
+- same 1st 2 attributes
+- a dom element for which we would like to observe what happens before and after it is clicked
+- a value supplier that supplies an observed value
+- a predicate that accepts the value supplied before click handlers are executed and after click handlers are executed, in order to compare the before and after
+  git

--- a/editor.js
+++ b/editor.js
@@ -298,19 +298,33 @@ BlocklyTest = {
   },
   getOrCreateNotYetPassing: function (index, message) {
     const checkId = `${this.currentTestName}_${index}`;
+    let $span = null;
     let $li = document.getElementById(checkId);
-    let $span = $li.querySelector("span.test-checkbox");
-    if (!$span) {
-      $span = document.createElement("span");
-      $span.setAttribute("class", "test-checkbox");
-      $span.innerHTML = "&check;&nbsp;";
-      $li.insertBefore($span, $li.firstChild);
+    if ($li) {
+      // can remove the $li codepath once we are fully moved to markdown
+      $span = $li.querySelector("span.test-checkbox");
+      if (!$span) {
+        $span = document.createElement("span");
+        $span.setAttribute("class", "test-checkbox");
+        $li.insertBefore($span, $li.firstChild);
+      }
+    } else {
+      const zeroMdSelector = `#${this.currentTestName} zero-md`;
+      let $zeroMd = document.querySelector(zeroMdSelector);
+      if ($zeroMd) {
+        let $instructionsRoot = $zeroMd.shadowRoot;
+        $span =
+          $instructionsRoot.querySelectorAll(`span.test-checkbox`)[index - 1];
+      }
     }
+
+    $span.innerHTML = "&check;&nbsp;";
+    // don't use css as is potentially in shadow dom with own stylesheet
     $span.style.color = "gray";
     $span.title = "This test is not currently passing: " + message;
     return {
       showPassing: function () {
-        $span.style.color = "chartreuse";
+        $span.style.color = "#32CD32"; // lime green
         $span.title = message;
       },
     };

--- a/exercises/introduction.md
+++ b/exercises/introduction.md
@@ -1,0 +1,29 @@
+## Introduction
+
+In this course, you will use _block-based programming_, like on code.org, to create JavaScript that changes the html on a web page.
+
+This "Introduction" has no tasks, only helpful information. Go to the first exercise whenever you're ready.
+
+- Static html can be written in the html textarea. "Static" means unchanging. In this case, we mean the original state, before the program changes anything).
+- Use blocks to create code that changes the html.
+- Click "run" to place the html in the space below the textarea and execute the generated code.
+- These exercises assume you have tried block based programming already. Do the [code.org course](https://studio.code.org/s/course3) before you start. You should at least have done the lessons up to Conditionals and While Loops.
+- Unlike code.org, in CYF Blocks you can go to the next exercise when you feel ready.
+  Grey checkmarks show that your current code doesn't solve the instruction. Green checkmarks show that it does.
+- The blocks create JavaScript code. You can view the result in the "Generated code" textarea. You are not expected to understand this code yet. (It's interesting to look at, though!)
+- The goal is to use the generated code in your own project. You will copy paste this code into a single .js file and add it, with html and css, to your course project.
+- The way the blocks work (and the code they generate) is very like the code you will learn in the long course. There are also some differences that make the code easier for new learners.
+
+### Definitions
+
+Some of the following may need a definition:
+
+- static vs dynamic
+- block based programming
+- html elements
+- html attributes
+- variable
+- array
+- function
+- function call
+- event handler? - not used, but would be convenient

--- a/exercises/set_colours.md
+++ b/exercises/set_colours.md
@@ -1,0 +1,41 @@
+## Setting colours
+
+We've seen how to change the text content of html elements, but we can also change the colour (and other attributes) of elements. Different kinds of **Values blocks** provide ways of setting texts, numbers and colours.
+
+Let's start with an html list of our favourite fruit in the "html" section.
+
+1.  each html list item (`<li>`) has a different id attribute so that we can refer to it using a css selector
+
+For example:
+
+```html
+<ul>
+  <li id="banana">Banana</li>
+  <li id="apple">Apple</li>
+  <li id="strawberry">Strawberry</li>
+</ul>
+```
+
+2.  Click "run" to see the rendered output
+
+Let's change the banana element's colour to yellow
+
+3.  Add an "`at the start`" block
+
+4.  Inside this block, add a "`find the element with id`" block using the id `<li>` element for Banana (`banana`)
+
+5.  Inside this block, add a "`set the attribute`" block. Select the _attribute_ "color" from the dropdown.
+
+6.  <span class="test-checkbox"></span>You can find a color picker block in the "Values" menu and set its colour to yellow. Add the yellow colour block to the previous "`set the attribute`" block, to set the colour to yellow.
+
+The colour for a banana is probably not easy to see against a white background.
+
+7. <span class="test-checkbox"></span>Add a second "`set the attribute`" block and set a dark color for the background.
+
+8. Click "run" to check the output looks like
+<ul style="background-color: azure;">
+      <li style="color:rgb(233, 233, 22);background-color: darkgrey;">Banana</li>
+      <li>Orange</li>
+</ul>
+
+<span class="test-checkbox"></span>Repeat the process above to colour each of the fruit. ( Hint: you can add multiple "`find the element with id`" blocks one after the other )

--- a/index.html
+++ b/index.html
@@ -1,9 +1,10 @@
 <html>
   <head>
+    <title>CYF Blocks - Unblock your future!</title>
     <style type="text/css">
       :root {
         --brand-red: rgb(220, 52, 52);
-        --brand-black: rgb(22,22,22);
+        --brand-black: rgb(22, 22, 22);
         --brand-white: rgb(255,255,255);
           }
 
@@ -87,6 +88,7 @@
       }
 
     </style>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/zerodevx/zero-md@2/dist/zero-md.min.js"></script>
   </head>
   <body>
     <script src="https://unpkg.com/blockly@7.20211209.0/blockly.min.js"></script>
@@ -99,59 +101,10 @@
       
       <div class="exercise" id="introduction">
       <h2>Introduction</h2>
-      <div class="instructions"><p>In this course, you will use <em>block-based programming</em>, 
-        like on code.org, to create JavaScript that changes the html on a web page.
-      </p>
-      <p>This "Introduction" has no tasks, only helpful information. Go to the first exercise whenever you're ready.</p>
-      <ul>
-        <li>
-          Static html can be written in the html textarea. "Static" means unchanging. In this case, we mean the original state, 
-          before the program changes anything).
-        </li>
-        <li>
-          Use blocks to create code that changes the html.
-        </li>
-        <li>
-          Click "run" to place the html in the space below the textarea and execute 
-          the generated code.
-        </li>
-        <li>
-          These exercises assume you have tried block based programming already. Do the <a href="https://studio.code.org/s/course3">code.org course</a> before you start. You should at least have done the lessons up to Conditionals and While Loops.
-        </li>
-        <li>
-          Unlike code.org, in CYF Blocks you can go to the next exercise when you feel ready.
-        </li> 
-          Grey checkmarks show that your current code doesn't solve the instruction. Green checkmarks show that it does.
-        </li>
-        <li>
-          The blocks create JavaScript code. You can view the result in the 
-          "Generated code" textarea. You are not expected to understand this code yet. (It's interesting to look at, though!)
-        </li>
-        <li>
-          The goal is to use the generated code in your own project. 
-          You will copy paste this code into a single .js file and add it, with html and css, 
-          to your course project.
-        </li>
-        <li>
-          The way the blocks work (and the code they generate) is very like the code you will learn in the long course. 
-          There are also some differences that make the code easier for new learners.
-        </li>
-      </ul>
-      <h3>Definitions</h3>
-      Some of the following may need a definition:
-      <ul>
-        <li>static vs dynamic</li>
-        <li>block based programming</li>
-        <li>html elements</li>
-        <li>html attributes</li>
-        <li>variable</li>
-        <li>array</li>
-        <li>function</li>
-        <li>function call</li>
-        <li>event handler? - not used, but would be convenient</li>
-      </ul>
-      </div></div>
-      
+      <div class="instructions">
+        <zero-md src="exercises/introduction.md"></zero-md>
+      </div>
+      </div>
       <div class="exercise" id="exercise_change_text">
       <h2>Modifying html dynamically: changing text</h2>
       <script>
@@ -235,32 +188,7 @@
       });
     </script>
       <div class="instructions">
-      <p>
-        Not only can we modify the contents of html elements, we can also change their properties, such as their colour. Different kinds of <b>Values blocks</b> provide ways of setting texts, numbers and colours.
-      </p>
-        <ol>
-            <li>Let's start with an html list of our favourite fruit in the "Static html" 
-                <ol>
-                    <li>each html list item (<code>&lt;li&gt;</code>) has a different id attribute so that we can refer to it from our program</li>
-                    <li>for example: <code class="start_code">&lt;ul&gt;<br>&lt;li id="banana"&gt;Banana&lt;/li&gt;<br>&lt;li id="apple"&gt;Apple&lt;/li&gt;<br>&lt;li id="strawberry"&gt;Strawberry&lt;/li&gt;<br>&lt;/ul&gt;</code></li>
-                    <li>you can click "run" to see the output</li>
-                </ol>
-            <li>Color the banana yellow
-                <ol>
-                    <li>Add an <span class="blockname">"at the start"</span> block</li>
-                    <li>Inside this block, add a <span class="blockname">"find the element with id"</span> block using the id of the &lt;li&gt; element for Banana (<code>banana</code>)</li>
-                    <li id="exercise_set_colours_1">Inside this block, add a <span class="blockname">"set the attribute"</span> block, pick "color" and set the value to any yellow colour using the <span class="blockname">colour picker</span> (you can find a color picker block in the "Values" menu).</li>
-                    <li id="exercise_set_colours_2">The colour for a banana is probably not easy to see against a white background. Add a second <span class="blockname">"set the attribute"</span> block and set a dark color for the background.</li>
-                    <li>Click "run" to check the output looks like
-                        <ul style="background-color: azure;">
-                            <li style="color:rgb(233, 233, 22);background-color: darkgrey;">Banana</li>
-                            <li>Orange</li>
-                        </ul>
-                    </li>
-                </ol>
-            </li>
-            <li id="exercise_set_colours_3">Repeat the process above to colour each of the fruit (hint: you can add multiple <span class="blockname">"find the element with id"</span> blocks one after the other). You can also change the background color if you like</li> 
-        </ol>
+      <zero-md src="exercises/set_colours.md"></zero-md>
        </div>
        <xml class="toolbox" style="display: none">
           <category name="Values" colour='%{BKY_TEXTS_HUE}'>


### PR DESCRIPTION
Use zero-md -> as lightweight as possible for now. Doesn't exclude a future build process

- loading mostly comes out of the box
- wait for all loading to be done before setting up exercises
- adapt loading of default html for each exercise
- adapt outputting of test results
- setup/document conventions for writing exercises

--
loading of exercises is complicated by zero-md's use of shadowdom -> might be able to simplify in future

-----
[View rendered README.md](https://github.com/CodeYourFuture/fundamentals-blockly/blob/gregdyke/markdown-support/README.md)
[View rendered exercises/introduction.md](https://github.com/CodeYourFuture/fundamentals-blockly/blob/gregdyke/markdown-support/exercises/introduction.md)
[View rendered exercises/set_colours.md](https://github.com/CodeYourFuture/fundamentals-blockly/blob/gregdyke/markdown-support/exercises/set_colours.md)