### PR TITLE
Unbreak share button on blocks.codeyourfuture.io

### DIFF
--- a/blockly-dom.js
+++ b/blockly-dom.js
@@ -82,32 +82,7 @@ Blockly.Blocks["arrays_getFirst"] = {
     this.setInputsInline(true);
     this.setOutput(true);
   },
-  /*
-   * mutationToDom and domToMutation are only here for backward compatibilty with xml (probably never needed)
-   */
-  /**
-   * Create XML to represent whether the block is a statement or a value.
-   * Also represent whether there is an 'AT' input.
-   * @return {!Element} XML storage element.
-   * @this {Blockly.Block}
-   */
-  mutationToDom: function () {
-    var container = Blockly.utils.xml.createElement("mutation");
-    var isStatement = !this.outputConnection;
-    container.setAttribute("statement", isStatement);
-    return container;
-  },
-  /**
-   * Parse XML to restore the 'AT' input.
-   * @param {!Element} xmlElement XML storage element.
-   * @this {Blockly.Block}
-   */
-  domToMutation: function (xmlElement) {
-    // Note: Until January 2013 this block did not have mutations,
-    // so 'statement' defaults to false and 'at' defaults to true.
-    var isStatement = xmlElement.getAttribute("statement") == "true";
-    this.updateStatement_(isStatement);
-  },
+
   /**
    * Switch between a value block and a statement block.
    * @param {boolean} newStatement True if the block should be a statement.

--- a/editor.js
+++ b/editor.js
@@ -163,6 +163,9 @@ BlocklyDomEditor.prototype.init = function (initHtml, initJsonBlockly) {
     var url = window.location.href
       .split("#")[0]
       .replace("index.html", "share.html");
+    if (!url.endsWith("share.html")) {
+      url += "share.html";
+    }
     let uri = url + "?v=" + encodeURIComponent(minifiedData);
     navigator.clipboard.writeText(uri);
     if (uri) {
@@ -170,7 +173,8 @@ BlocklyDomEditor.prototype.init = function (initHtml, initJsonBlockly) {
       let toast = document.getElementById("toast");
       let toastTitle = toast.querySelector(".toast-title");
 
-      toastTitle.innerHTML = "Share link copied to clipboard!";
+      toastTitle.innerHTML =
+        "Share link copied to clipboard!<br>(it's a bit long but don't worry)";
       toast.classList.toggle("is-open");
       setTimeout(() => {
         toast.classList.toggle("is-open");
@@ -197,10 +201,8 @@ BlocklyDomEditor.prototype.show = function () {
 BlocklyDomEditor.backupBlocks_ = function (workspace, $htmlTextarea, id) {
   if ("localStorage" in window) {
     var json = JSON.stringify(Blockly.serialization.workspaces.save(workspace));
-    // Gets the current URL, not including the hash.
-    var url = window.location.href.split("#")[0];
-    window.localStorage.setItem(url + id, json);
-    window.localStorage.setItem(url + "html" + id, $htmlTextarea.value);
+    window.localStorage.setItem(id, json);
+    window.localStorage.setItem("html" + id, $htmlTextarea.value);
   }
 };
 
@@ -224,24 +226,19 @@ BlocklyDomEditor.backupOnUnload = function (workspace, $htmlTextarea, id) {
  * @param {String} id unique id, must be stable across page reloads
  */
 BlocklyDomEditor.restoreBlocks = function (workspace, $htmlTextarea, id) {
-  var url = window.location.href.split("#")[0];
-  if ("localStorage" in window && window.localStorage[url + id]) {
-    let serialised = window.localStorage[url + id];
-    if (serialised[0] === "<") {
-      let xml = Blockly.Xml.textToDom(serialised);
-      Blockly.Xml.domToWorkspace(xml, workspace);
-    } else {
-      let json = JSON.parse(serialised);
-      console.log(
-        "chars",
-        id,
-        serialised.length,
-        JSONCrush.crush(serialised).length
-      );
-      Blockly.serialization.workspaces.load(json, workspace);
-    }
+  if ("localStorage" in window && window.localStorage[id]) {
+    let serialised = window.localStorage[id];
 
-    let html = window.localStorage[url + "html" + id];
+    let json = JSON.parse(serialised);
+    console.log(
+      "chars",
+      id,
+      serialised.length,
+      JSONCrush.crush(serialised).length
+    );
+    Blockly.serialization.workspaces.load(json, workspace);
+
+    let html = window.localStorage["html" + id];
     if (html) {
       $htmlTextarea.value = html;
     }


### PR DESCRIPTION
- page may be accessed with or without index.html -> remove url from index storage prefix as it was unnecessary anyway
- share link construction relied on index.html being used -> make it optional <host>/[index.html]#exercise_id
- also remove legacy code that loaded xml serialisation