### PR TITLE
pin to blockly release 8.0.3 in share page as 8.0.4 breaks it at current

### DIFF
--- a/share.html
+++ b/share.html
@@ -57,7 +57,7 @@
     </style>
   </head>
   <body>
-    <script src="https://unpkg.com/blockly/blockly.min.js"></script>
+    <script src="https://unpkg.com/blockly@8.0.3/blockly.min.js"></script>
     <script src="blockly-dom.js"></script>
     <script src="blockly-cyf.js"></script>
     <script src="jsoncrush.js"></script>


### PR DESCRIPTION
While there is a wider issue that different versions of Blockly are referenced on index.html (7.20211209.0) and share.html (until now, whichever the latest release of Blockly was), it looks like the latest Blockly release (8.0.4) breaks our share page at present, possibly to do with the reworking of messaging in that version. (I haven't gotten to the bottom of it.)

This PR temporarily pins the Blockly version to 8.0.3, which was the last known good version.