### PR TITLE
equalise versions of blockly used by main site and share page

### DIFF
--- a/share.html
+++ b/share.html
@@ -57,7 +57,7 @@
     </style>
   </head>
   <body>
-    <script src="https://unpkg.com/blockly@8.0.3/blockly.min.js"></script>
+    <script src="https://unpkg.com/blockly@7.20211209.0/blockly.min.js"></script>
     <script src="blockly-dom.js"></script>
     <script src="blockly-cyf.js"></script>
     <script src="jsoncrush.js"></script>


### PR DESCRIPTION
Continuing from https://github.com/CodeYourFuture/fundamentals-blockly/pull/88, this PR equalises the versions used by both the main site (i.e. the exercises) and the share page, for the sake of having them the same.