### PR TITLE
Create toggle block

### DIFF
--- a/blockly-dom.js
+++ b/blockly-dom.js
@@ -280,11 +280,6 @@ Blockly.defineBlocksWithJsonArray([
     message0: "toggle the class %1",
     args0: [
       {
-        type: "field_dropdown",
-        name: "PROPERTY",
-        options: [["class", "class"]],
-      },
-      {
         type: "input_value",
         name: "VALUE",
       },

--- a/blockly-dom.js
+++ b/blockly-dom.js
@@ -277,7 +277,7 @@ Blockly.defineBlocksWithJsonArray([
   },
   {
     type: "toggle_attribute",
-    message0: "toggle the attribute %1 = %2",
+    message0: "toggle the class %1",
     args0: [
       {
         type: "field_dropdown",

--- a/blockly-dom.js
+++ b/blockly-dom.js
@@ -276,6 +276,25 @@ Blockly.defineBlocksWithJsonArray([
     extensions: ["validate_in_with_context"],
   },
   {
+    type: "toggle_attribute",
+    message0: "toggle the attribute %1 = %2",
+    args0: [
+      {
+        type: "field_dropdown",
+        name: "PROPERTY",
+        options: [["class", "class"]],
+      },
+      {
+        type: "input_value",
+        name: "VALUE",
+      },
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    colour: 60,
+    extensions: ["validate_in_with_context"],
+  },
+  {
     type: "set_content",
     message0: "set the text content to %1",
     args0: [
@@ -604,6 +623,16 @@ Blockly.JavaScript["set_attribute"] = function (block) {
       ");\n"
     );
   }
+};
+
+Blockly.JavaScript["toggle_attribute"] = function (block) {
+  let value = Blockly.JavaScript.valueToCode(
+    block,
+    "VALUE",
+    Blockly.JavaScript.ORDER_NONE
+  );
+  let withContextVariable = Blockly.JavaScript.getWithContextVariable();
+  return withContextVariable + `.classList.toggle(${value});\n`;
 };
 
 Blockly.JavaScript["set_content"] = function (block) {

--- a/index.html
+++ b/index.html
@@ -1056,6 +1056,7 @@
           </value>
         </block>
         <block type="set_attribute"></block>
+        <block type="toggle_attribute"></block>
         <block type="remove_contents"></block>
         <block type="get_input_value_with_id"></block>
         <block type="element_clicked_current"></block>


### PR DESCRIPTION
We made this block so I could set a challenge in the HTML-CSS module project to return to blockly and make a hamburger menu.

I wanted the code to be a little closer to how one might write it in real life. It's not quite what one would really do, as we nest the function inside the listener, but it's closer and more comprehensible.

Our block only toggles class for now, but could toggle other attributes in the future, so we called it toggle Attribute. We made it available in the default toolbox, so it shows up on the intro page and the projects pages.

## How to test

Given http://127.0.0.1:5503/index.html#introduction
And this block of static html:

```
<style>
.is-hidden {visibility: hidden }
</style>
<button id="button">Toggle Menu</button>
<ul class="menu">
<li><a href="#">Link</a></li>
<li><a href="#">Link</a></li>
<li><a href="#">Link</a></li>
</ul>
```

When I compose these blocks:

When the element with id [button] is clicked =>
find all the elements using css selector [.menu]
and with each => toggle the attribute [class] = => "is-hidden"

When I press [RUN]
Then this block appears:
[Toggle Menu]
- Link
- Link
- Link

When I click [Toggle Menu]
Then the list disappears

When I click [Toggle Menu]
Then the list appears

(Sorry I absent mindedly pushed this to main, have reset and opened as PR)

