### PR TITLE
flip view back, add link to examples

### DIFF
--- a/exercises.js
+++ b/exercises.js
@@ -77,20 +77,17 @@ function pageSetup(isExample = false) {
       exercise.$blockly = document.createElement("div");
       exercise.$exercise.insertBefore(
         exercise.$blockly,
-        exercise.$instructions
+        exercise.$h2.nextElementSibling
       );
       exercise.id = i;
       if (exercise.$exercise.id) {
         exercise.id = exercise.$exercise.id;
       }
-      // let the exercise render before creating the BlocklyDomEditor
-      // TODO write a mutation observer to detect when the zero-md has rendered
-      setTimeout(
-        (exercise.blocklyDomEditor = new BlocklyDomEditor(
-          exercise.$blockly,
-          exercise.id
-        )),
-        1000
+      // TODO write a mutation observer to detect when the zero-md has rendered so we can
+      // write a better layout
+      exercise.blocklyDomEditor = new BlocklyDomEditor(
+        exercise.$blockly,
+        exercise.id
       );
 
       let initJsonBlockly = undefined;

--- a/index.html
+++ b/index.html
@@ -1013,7 +1013,7 @@
 
     <footer>
       <h3>CYF Blocks is a project of <a href="https://codeyourfuture.io">Code Your Future</a></h3>
-      <p>Recap your HTML/CSS knowledge with this <a href="https://scrimba.com/learn/htmlcss">free crash course</a> on Scrimba.</p>
+      <p>Recap your HTML/CSS knowledge with this <a href="https://scrimba.com/learn/htmlcss">free crash course</a> on Scrimba. | Check out our <a href="examples.html">Helpful Examples</a> if you are struggling to get started</p>
     </footer>
      <section role="dialog" aria-live="assertive" class="toast" id="toast" aria-labelledby="toast-title">
       <h4 class="toast-title"></h4>


### PR DESCRIPTION
blockly is fierce to do UI battle with, now I remember

The race conditions of blockly vs zeromd means really the markdown needs to go below blockly or it screws up and overlaps from time to time on page load. This feels super fixable, but not the day before ITD opens, so I've reverted the order for now and added a comment where the fix should go.

I also added a link to the examples page in the footer